### PR TITLE
Type and API rectification

### DIFF
--- a/compost_rpc/compost_rpc.py
+++ b/compost_rpc/compost_rpc.py
@@ -1681,12 +1681,12 @@ enum RpcId {{
 /**
  * {notif.__doc__}
  */
-int16_t {notif.name}_store(uint8_t *tx_buf{params});
+size_t {notif.name}_store(uint8_t *tx_buf{params});
 """
             protocol_source += f"""/**
 * Serialization function for {notif.name} notification
 */
-int16_t {notif.name}_store(uint8_t *tx_buf{params})
+size_t {notif.name}_store(uint8_t *tx_buf{params})
 {{
     struct CompostMsg tx = {{
         .header = {{ .txn = 0 }},

--- a/compost_rpc/compost_rpc.py
+++ b/compost_rpc/compost_rpc.py
@@ -1681,15 +1681,15 @@ enum RpcId {{
 /**
  * {notif.__doc__}
  */
-int16_t {notif.name}_store(uint8_t *tx_buf, size_t tx_buf_size{params});
+int16_t {notif.name}_store(uint8_t *tx_buf{params});
 """
             protocol_source += f"""/**
 * Serialization function for {notif.name} notification
 */
-int16_t {notif.name}_store(uint8_t *tx_buf, size_t tx_buf_size{params})
+int16_t {notif.name}_store(uint8_t *tx_buf{params})
 {{
     struct CompostMsg tx = {{
-        .txn   = 0,
+        .header = {{ .txn = 0 }},
         .payload_buf = tx_buf + PAYLOAD_OFFSET
     }};
     uint8_t *dest = tx.payload_buf;
@@ -1698,9 +1698,11 @@ int16_t {notif.name}_store(uint8_t *tx_buf, size_t tx_buf_size{params})
             for param_name, param_type in notif.get_param_items():
                 protocol_source.add(self._store_call(param_type.annotation, param_name))
             protocol_source.indent_dec()
-            protocol_source += f"""    tx.rpc_id = {notif.name.upper()};
-    tx.len = compost_bytes_to_words(dest - tx.payload_buf);
-    return compost_header_set(tx_buf, tx_buf_size, tx);
+            protocol_source += f"""    tx.header.rpc_id = {notif.name.upper()};
+    size_t payload_len = dest - tx.payload_buf;
+    tx.header.wlen = compost_bytes_to_words(payload_len);
+    compost_header_store(tx_buf, tx.header);
+    return 4 + payload_len;
 }}
 
 """
@@ -1750,10 +1752,10 @@ void invoke_{rpc.name}({", ".join(invoke_params)})
                 invoke_fn.add('uint8_t *dest = tx->payload_buf;')
                 invoke_fn.add(self._store_call(sig.return_annotation, "ret"))
             if sig.return_annotation is Signature.empty:
-                invoke_fn.add("tx->len = 0;")
+                invoke_fn.add("tx->header.wlen = 0;")
             else:
-                invoke_fn.add("tx->len = compost_bytes_to_words(dest - tx->payload_buf);")
-            invoke_fn.add(f"tx->rpc_id = {rpc.name.upper()};")
+                invoke_fn.add("tx->header.wlen = compost_bytes_to_words(dest - tx->payload_buf);")
+            invoke_fn.add(f"tx->header.rpc_id = {rpc.name.upper()};")
             invoke_fn += "}\n"
 
             protocol_header += invoke_prototype
@@ -1763,13 +1765,13 @@ void invoke_{rpc.name}({", ".join(invoke_params)})
         rpc_id_fns = """
 void compost_unknown_msg(struct CompostMsg *tx)
 {
-    tx->rpc_id = UNKNOWN_MSG;
-    tx->len = 0;
+    tx->header.rpc_id = UNKNOWN_MSG;
+    tx->header.wlen = 0;
 }
 
 void compost_invoke_switch(struct CompostMsg *tx, const struct CompostMsg rx)
 {
-    switch (rx.rpc_id) {
+    switch (rx.header.rpc_id) {
 """
         for rpc in self._protocol._rpcs.values():
             if rpc.is_notification and not endpoint.is_call_inbound(rpc):

--- a/compost_rpc/lib/c/header_template.py
+++ b/compost_rpc/lib/c/header_template.py
@@ -37,12 +37,16 @@ ${version_info}
  */
 #define COMPOST_PAYLOAD_LEN(msg) (4 * (((uint8_t *)msg)[0]))
 
+struct CompostHeader {
+    uint8_t wlen;    ///< Word length of the payload (payload length in bytes is wlen * 4)
+    uint8_t txn;     ///< Transaction identifier
+    uint16_t rpc_id; ///< RPC identifier
+    bool resp;       ///< Response flag
+};
+
 struct CompostMsg {
-    uint16_t len;
-    uint16_t rpc_id;
-    const uint16_t payload_buf_size;
-    uint8_t txn;
-    bool resp;
+    struct CompostHeader header;
+    const size_t payload_buf_size;
     uint8_t *payload_buf;
 };
 
@@ -258,7 +262,23 @@ struct CompostAlloc {
  * @return Size of valid data in bytes in the transmit buffer, or zero if there
  * is no message to send, or negative value if there was an error
  */
-int16_t compost_msg_process(uint8_t *, const uint16_t, uint8_t *const, const uint16_t);
+int compost_msg_process(uint8_t *tx_buf, const size_t tx_buf_size, uint8_t *const rx_buf, const size_t rx_buf_size);
+
+/**
+ * @brief Loads the message header from the buffer.
+ * @param buf Pointer to the buffer containing the header
+ * @param header Pointer to the CompostHeader struct where to store the header data
+ * @return Zero on success, or negative value if there was an error (e.g. invalid header)
+ */
+int compost_header_load(uint8_t *buf, struct CompostHeader *header);
+
+/**
+ * @brief Stores the message header to the buffer.
+ * @param buf Pointer to the buffer where to store the header
+ * @param header Pointer to the CompostHeader struct containing the header data
+ * @return Zero on success, or negative value if there was an error (e.g. insufficient buffer size)
+ */
+int compost_header_store(uint8_t *buf, const struct CompostHeader header);
 
 /**
  * @brief Initializes an allocator.

--- a/compost_rpc/lib/c/source_template.py
+++ b/compost_rpc/lib/c/source_template.py
@@ -38,7 +38,7 @@ source_parts.append(SourcePart(False,'''/** @file
     } while (0)
 #endif
 
-#define LEN_OFFSET                0
+#define WLEN_OFFSET               0
 #define TXN_OFFSET                1
 #define RPC_ID_HI_AND_RESP_OFFSET 2
 #define RPC_ID_LO_OFFSET          3
@@ -401,66 +401,78 @@ static inline uint32_t compost_u64_field_get(uint64_t backing, uint32_t offset_b
 /*            P U B L I C   A P I   F U N C T I O N S                         */
 /******************************************************************************/
 
-int16_t compost_header_set(uint8_t *tx_buf, uint16_t tx_buf_size, const struct CompostMsg tx)
+int compost_header_load(uint8_t *buf, struct CompostHeader *header)
 {
-    if (tx_buf == NULL ) {
-        return COMPOST_EINVAL;
-    }
-    if (tx_buf_size < 4) {
-        return COMPOST_EMSGSIZE;
-    }
-    COMPOST_ASSERT(tx.rpc_id <= 0x0FFF);
-    tx_buf[LEN_OFFSET] = tx.len;
-    tx_buf[TXN_OFFSET] = tx.txn;
-    tx_buf[RPC_ID_HI_AND_RESP_OFFSET] = tx.rpc_id >> 8;
-    if (tx.resp) {
-        tx_buf[RPC_ID_HI_AND_RESP_OFFSET] |= RESP_MASK;
-    }
-    tx_buf[RPC_ID_LO_OFFSET] = tx.rpc_id;
-    if (tx.len > 255) {
-        return COMPOST_EMSGSIZE;
-    }
-    int16_t msg_size = (tx.len * 4) + 4;
-    if (msg_size > tx_buf_size) {
-        return COMPOST_EMSGSIZE;
-    }
-    return msg_size;
-}
-
-int16_t compost_msg_process(uint8_t *tx_buf, const uint16_t tx_buf_size, uint8_t *const rx_buf,
-                            const uint16_t rx_buf_size)
-{
-    if ((rx_buf_size < 4) || (tx_buf_size < 4) || tx_buf == NULL || rx_buf == NULL) {
+    if (buf == NULL || header == NULL) {
         return COMPOST_EINVAL;
     }
 
-    uint8_t rpc_id_hi = rx_buf[RPC_ID_HI_AND_RESP_OFFSET] & RPC_ID_HI_MASK;
-    uint8_t flags = rx_buf[RPC_ID_HI_AND_RESP_OFFSET] & FLAGS_MASK;
+    uint8_t rpc_id_hi = buf[RPC_ID_HI_AND_RESP_OFFSET] & RPC_ID_HI_MASK;
+    uint8_t flags = buf[RPC_ID_HI_AND_RESP_OFFSET] & FLAGS_MASK;
 
     if (flags & ~RESP_MASK) {
         return COMPOST_EFLAGS;
     }
 
-    const struct CompostMsg rx = {.len = rx_buf[LEN_OFFSET],
-                                   .txn = rx_buf[TXN_OFFSET],
-                                   .resp = (flags & RESP_MASK) != 0,
-                                   .rpc_id = ((uint16_t)rpc_id_hi << 8) | rx_buf[RPC_ID_LO_OFFSET],
+    header->wlen = buf[WLEN_OFFSET];
+    header->txn = buf[TXN_OFFSET];
+    header->resp = flags & RESP_MASK;
+    header->rpc_id = ((uint16_t)rpc_id_hi << 8) | buf[RPC_ID_LO_OFFSET];
+    return 0;
+}
+
+int compost_header_store(uint8_t *buf, const struct CompostHeader header)
+{
+    if (buf == NULL) {
+        return COMPOST_EINVAL;
+    }
+    COMPOST_ASSERT(header.rpc_id <= 0x0FFF);
+    buf[WLEN_OFFSET] = header.wlen;
+    buf[TXN_OFFSET] = header.txn;
+    buf[RPC_ID_HI_AND_RESP_OFFSET] = header.rpc_id >> 8;
+    if (header.resp) {
+        buf[RPC_ID_HI_AND_RESP_OFFSET] |= RESP_MASK;
+    }
+    buf[RPC_ID_LO_OFFSET] = header.rpc_id;
+    return 0;
+}
+
+int compost_msg_process(uint8_t *tx_buf, const size_t tx_buf_size, uint8_t *const rx_buf,
+                            const size_t rx_buf_size)
+{
+    if ((rx_buf_size < 4) || (tx_buf_size < 4) || tx_buf == NULL || rx_buf == NULL) {
+        return COMPOST_EINVAL;
+    }
+
+    struct CompostHeader rx_header;
+    int ret = compost_header_load(rx_buf, &rx_header);
+    if (ret) {
+        return ret;
+    }
+
+    const struct CompostMsg rx = { .header = rx_header,
                                    .payload_buf = rx_buf + PAYLOAD_OFFSET,
                                    .payload_buf_size = rx_buf_size - PAYLOAD_OFFSET};
 
-    struct CompostMsg tx = {.txn = rx.txn,
-                             .resp = true,
+    struct CompostMsg tx = { .header.txn = rx.header.txn,
+                             .header.resp = true,
+                             .header.wlen = 0,
+                             .header.rpc_id = 0,
                              .payload_buf_size = tx_buf_size - PAYLOAD_OFFSET,
                              .payload_buf = tx_buf + PAYLOAD_OFFSET};
 
-    if (rx.txn != 0 && rx.resp == true) {
+    if (rx.header.txn != 0 && rx.header.resp == true) {
         return COMPOST_ETXN; // We don't support sending RPC requests, so we can't get a response
     }
 
     compost_invoke_switch(&tx, rx);
 
-    if (tx.txn || tx.len) {
-        return compost_header_set(tx_buf, tx_buf_size, tx);
+    if (tx.header.txn || tx.header.wlen) {
+        ret = compost_header_store(tx_buf, tx.header);
+        if (ret) {
+            return ret;
+        }
+        return 4 + (tx.header.wlen * 4); // Total message length is header (4 bytes) + payload
     } else {
         return 0; // Nothing to send
     }

--- a/docs/_static/image/getting_started/msg_structure.json
+++ b/docs/_static/image/getting_started/msg_structure.json
@@ -1,8 +1,8 @@
 [
-    { "name": "LEN",      "bits": 8,  "type": 2 },
+    { "name": "WLEN",     "bits": 8,  "type": 2 },
     { "name": "TXN",      "bits": 8,  "type": 3 },
     { "name": "Reserved", "bits": 3,  "type": 5, "rotate": -50 },
     { "name": "RESP",     "bits": 1,  "type": 4, "rotate": -90 },
     { "name": "RPC_ID",   "bits": 12, "type": 7 },
-    { "name": "PAYLOAD",  "bits": 32, "type": 1, "attr": "Variable length payload. Length is 4 * LEN bytes." }
+    { "name": "PAYLOAD",  "bits": 32, "type": 1, "attr": "Variable length payload. Length is 4 * WLEN bytes." }
 ] 

--- a/docs/_static/image/getting_started/msg_structure.svg
+++ b/docs/_static/image/getting_started/msg_structure.svg
@@ -67,7 +67,7 @@
       </g>
       <g>
         <g>
-          <rect width="198" height="71" field="LEN" style="fill-opacity:0.1;fill:hsl(0,100%,50%)"/>
+          <rect width="198" height="71" field="WLEN" style="fill-opacity:0.1;fill:hsl(0,100%,50%)"/>
           <rect x="198" width="198" height="71" field="TXN" style="fill-opacity:0.1;fill:hsl(80,100%,50%)"/>
           <rect x="396" width="74" height="71" field="Reserved" style="fill-opacity:0.1;fill:hsl(45,100%,50%)"/>
           <rect x="470" width="25" height="71" field="RESP" style="fill-opacity:0.1;fill:hsl(170,100%,50%)"/>
@@ -77,7 +77,7 @@
         <g transform="translate(12,35)">
           <g transform="translate(87)">
             <text y="6">
-              <tspan>LEN</tspan>
+              <tspan>WLEN</tspan>
             </text>
           </g>
           <g transform="translate(284)">
@@ -188,7 +188,7 @@
         <g transform="translate(12,79)">
           <g transform="translate(383)">
             <text y="6">
-              <tspan>Variable length payload. Length is 4 * LEN bytes.</tspan>
+              <tspan>Variable length payload. Length is 4 * WLEN bytes.</tspan>
             </text>
           </g>
         </g>

--- a/docs/_static/image/getting_started/msg_structure_white.svg
+++ b/docs/_static/image/getting_started/msg_structure_white.svg
@@ -67,7 +67,7 @@
       </g>
       <g>
         <g>
-          <rect width="198" height="71" field="LEN" style="fill-opacity:0.1;fill:hsl(0,100%,50%)"/>
+          <rect width="198" height="71" field="WLEN" style="fill-opacity:0.1;fill:hsl(0,100%,50%)"/>
           <rect x="198" width="198" height="71" field="TXN" style="fill-opacity:0.1;fill:hsl(80,100%,50%)"/>
           <rect x="396" width="74" height="71" field="Reserved" style="fill-opacity:0.1;fill:hsl(45,100%,50%)"/>
           <rect x="470" width="25" height="71" field="RESP" style="fill-opacity:0.1;fill:hsl(170,100%,50%)"/>
@@ -77,7 +77,7 @@
         <g transform="translate(12,35)">
           <g transform="translate(87)">
             <text y="6">
-              <tspan>LEN</tspan>
+              <tspan>WLEN</tspan>
             </text>
           </g>
           <g transform="translate(284)">
@@ -188,7 +188,7 @@
         <g transform="translate(12,79)">
           <g transform="translate(383)">
             <text y="6">
-              <tspan>Variable length payload. Length is 4 * LEN bytes.</tspan>
+              <tspan>Variable length payload. Length is 4 * WLEN bytes.</tspan>
             </text>
           </g>
         </g>

--- a/test/mock/main.c
+++ b/test/mock/main.c
@@ -120,13 +120,13 @@ int main(int argc, char *argv[])
         case 0x0e00:
             time(&current_epoch);
             struct MockDate date = epoch_to_date_handler(current_epoch, &alloc);
-            tx_len = notify_date_store(tx_buf, sizeof(tx_buf), date);
+            tx_len = notify_date_store(tx_buf, date);
             break;
         case 0x0e02:
-            tx_len = notify_heartbeat_store(tx_buf, sizeof(tx_buf));
+            tx_len = notify_heartbeat_store(tx_buf);
             break;
         case 0x0e03:
-            tx_len = notify_bitwise_complement_store(tx_buf, sizeof(tx_buf), 0xAAAAAAAAAAAAAAAA, 0x5555555555555555);
+            tx_len = notify_bitwise_complement_store(tx_buf, 0xAAAAAAAAAAAAAAAA, 0x5555555555555555);
             break;
         default:
             notif_requested = false;

--- a/test/protocol_impl.c
+++ b/test/protocol_impl.c
@@ -241,7 +241,7 @@ void notify_motor_control_handler(struct MockMotorControl control)
         compost_slice_set(report.voltage, i, i + 11);
         compost_slice_set(report.current, i, i + 41);
     }
-    int16_t tx_len = notify_motor_report_store(tx_buf_notif, sizeof(tx_buf_notif), report);
+    int16_t tx_len = notify_motor_report_store(tx_buf_notif, report);
     if (tx_len > 0) {
         fwrite(tx_buf_notif, 1, tx_len, stdout);
         fflush(stdout);
@@ -262,7 +262,7 @@ void notify_motor_report_handler(struct MockMotorReport report)
     control.state = MOTOR_STATE_STOP;
     control.direction = MOTOR_DIRECTION_DOWN;
     control.pwm_duty = 1200;
-    int16_t tx_len = notify_motor_control_store(tx_buf_notif, sizeof(tx_buf_notif), control);
+    int16_t tx_len = notify_motor_control_store(tx_buf_notif, control);
     if (tx_len > 0) {
         fwrite(tx_buf_notif, 1, tx_len, stdout);
         fflush(stdout);
@@ -290,7 +290,7 @@ void notify_bitfields_handler(struct BitfieldStruct config)
     config.ststart = ~config.ststart;
     config.temp = VOLTAGES_MV_37_50;
     config.tnom = ~config.tnom;
-    uint16_t tx_len = notify_bitfields_store(tx_buf_notif, sizeof(tx_buf_notif), config);
+    uint16_t tx_len = notify_bitfields_store(tx_buf_notif, config);
     fwrite(tx_buf_notif, 1, tx_len, stdout);
     fflush(stdout);
 }


### PR DESCRIPTION
Makes `compost_header_load` and `store` functions public. Changes some type signatures to more common types. Functionally not much change.

I have removed the buffer size parameter from notification_store functions, because the size check will not work for slices using the zero copy approach - data are already written when you call the notification_store function.

Changed the header field LEN to WLEN to better signify that it's the length in words not bytes.