### PR TITLE
Fix serialization of nested structs with bitfields

### DIFF
--- a/compost_rpc/compost_rpc.py
+++ b/compost_rpc/compost_rpc.py
@@ -11,7 +11,7 @@ import typing
 import uuid
 import socket
 from string import Template
-from dataclasses import dataclass, astuple
+from dataclasses import dataclass
 from queue import Queue, Empty
 from pathlib import Path
 from datetime import datetime
@@ -585,8 +585,8 @@ def pack_payload(types: list[type], *args) -> bytes:
     def _pack(buffer: memoryview, offset: MemUnit, t: type, value) -> MemUnit:
         if _issubclass(t, (_CompostStruct, )):
             offset.byte_align()
-            for (_, member_type), member in zip(t.__annotations__.items(), astuple(value)):
-                offset = _pack(buffer, offset, member_type, member)
+            for member_name, member_type in t.__annotations__.items():
+                offset = _pack(buffer, offset, member_type, getattr(value, member_name))
         elif _issubclass(t, (bytes, str)):
             offset.byte_align()
             if _issubclass(t, (str,)):

--- a/csharp/src/CompostRpc/Serialization.cs
+++ b/csharp/src/CompostRpc/Serialization.cs
@@ -118,6 +118,19 @@ public static class Serialization
         return true;
     }
 
+    private static BufferUnit GetCompostStructSize(Type type, Func<PropertyInfo, BufferUnit> getPropertySize)
+    {
+        BufferUnit size = BufferUnit.Zero;
+        foreach (var property in GetCompostStructProperties(type))
+        {
+            if (property.PackedSize is not null)
+                size += property.PackedSize.Value;
+            else
+                size = size.AlignToBytes() + getPropertySize(property.ReflectionInfo);
+        }
+        return size.AlignToBytes();
+    }
+
     /// <summary>
     /// Get size of representation in a compost protocol for Type
     /// </summary>
@@ -145,13 +158,7 @@ public static class Serialization
         }
         else if (IsTypeCompostStruct(type))
         {
-            BufferUnit classSize = new(0);
-            var properties = GetCompostStructProperties(type);
-            foreach (var property in properties)
-                if (property.PackedSize is not null)
-                    classSize += property.PackedSize.Value;
-                else
-                    classSize += GetTypeSize(property.ReflectionInfo.PropertyType);
+            BufferUnit classSize = GetCompostStructSize(type, property => GetTypeSize(property.PropertyType));
             _typeSizeCache.TryAdd(type, classSize);
             return classSize;
         }
@@ -185,13 +192,7 @@ public static class Serialization
         }
         else if (IsTypeCompostStruct(argType) && !IsTypeStatic(argType))
         {
-            BufferUnit classSize = new(0);
-            foreach (var property in GetCompostStructProperties(argType))
-                if (property.PackedSize is not null)
-                    classSize += property.PackedSize.Value;
-                else
-                    classSize += GetObjectSize(property.ReflectionInfo.GetValue(arg, null));
-            return classSize;
+            return GetCompostStructSize(argType, property => GetObjectSize(property.GetValue(arg, null)));
         }
         else
             return GetTypeSize(argType);
@@ -425,6 +426,7 @@ public static class Serialization
     /// </param>
     public static void Serialize(object arg, byte[] buffer, ref BufferUnit offset)
     {
+        offset = offset.AlignToBytes();
         Type argType = arg?.GetType() ?? throw new ArgumentNullException(nameof(arg));
         if (argType.IsEnum)
         {
@@ -460,6 +462,7 @@ public static class Serialization
         }
         else
             SerializePrimitive(arg, buffer, ref offset);
+        offset = offset.AlignToBytes();
     }
 
     /// <inheritdoc cref="Serialize"/>
@@ -509,6 +512,7 @@ public static class Serialization
     /// <param name="argType">Type of object to deserialize</param>
     public static object Deserialize(Type argType, ReadOnlySpan<byte> buffer, ref BufferUnit offset)
     {
+        offset = offset.AlignToBytes();
         object arg;
         if (argType.IsEnum)
         {
@@ -559,6 +563,7 @@ public static class Serialization
         {
             arg = DeserializePrimitive(argType, buffer, ref offset);
         }
+        offset = offset.AlignToBytes();
         return arg;
     }
 

--- a/csharp/tests/CompostRpc.IntegrationTests/NotificationTestsBase.cs
+++ b/csharp/tests/CompostRpc.IntegrationTests/NotificationTestsBase.cs
@@ -56,4 +56,29 @@ public abstract class NotificationTestsBase
         ulong b = await FetchNotificationArg<ulong>();
         Assert.True(a == ~b);
     }
+
+    [Fact]
+    public async Task NotifyNestedBitfieldsByTriggerRpcTest()
+    {
+        _unit.NotifyBitfields += (a, b) => _notificationArgs.Post((a, b));
+        await _unit.TriggerNotificationAsync(0xe04);
+
+        (BitfieldStruct a, NestedBitfieldStruct b) = await FetchNotificationArg<(BitfieldStruct, NestedBitfieldStruct)>();
+        Assert.Equal(0U, a.Channel);
+        Assert.Equal(1U, a.Inom);
+        Assert.Equal(1U, a.Tnom);
+        Assert.Equal(Voltages.Mv110_92, a.Temp);
+        Assert.Equal(1U, b.Leading);
+        Assert.Equal(0xA5U, b.Fields.Channel);
+        Assert.Equal(0x12U, b.Fields.Inom);
+        Assert.Equal(0x9U, b.Fields.Hsc);
+        Assert.Equal(0x155U, b.Fields.Tnom);
+        Assert.Equal(Voltages.Mv63_08, b.Fields.Temp);
+        Assert.Equal(0x5U, b.Fields.Ststart);
+        Assert.Equal(1U, b.Fields.Ccm);
+        Assert.Equal(0U, b.Fields.Set);
+        Assert.Equal(1U, b.Fields.State);
+        Assert.Equal(0U, b.Fields.Clear);
+        Assert.Equal(Status.Warn, b.Status);
+    }
 }

--- a/csharp/tests/CompostRpc.IntegrationTests/TestProtocol/TestProtocol.Implementation.cs
+++ b/csharp/tests/CompostRpc.IntegrationTests/TestProtocol/TestProtocol.Implementation.cs
@@ -15,15 +15,23 @@ public partial class TestProtocol : Protocol
     [Rpc(0x222)]
     public Task<uint> AddIntUnimplementedAsync(uint a, uint b)
         => InvokeRpcAsync<uint>([a, b]);
-    
+
     [RpcImplementation(nameof(TriggerNotificationAsync))]
-    public void TriggerNotificationImpl (ushort rpcId)
+    public void TriggerNotificationImpl(ushort rpcId)
     {
-        object[]? data = rpcId switch 
+        object[]? data = rpcId switch
         {
             0xe00 => [EpochToDateImpl((int)DateTimeOffset.Now.ToUnixTimeSeconds())],
             0xe02 => [true],
             0xe03 => [0xAAAAAAAAAAAAAAAA, 0x5555555555555555],
+            0xe04 => [
+                new BitfieldStruct { Channel = 0, Inom = 1, Hsc = 0, Tnom = 1, Temp = Voltages.Mv110_92, Ststart = 1, Ccm = 0, Set = 1, State = 0, Clear = 1 },
+                new NestedBitfieldStruct {
+                    Leading = 1,
+                    Fields = new BitfieldStruct { Channel = 0xA5, Inom = 0x12, Hsc = 0x9, Tnom = 0x155, Temp = Voltages.Mv63_08, Ststart = 0x5, Ccm = 1, Set = 0, State = 1, Clear = 0 },
+                    Status = Status.Warn
+                }
+            ],
             _ => throw new NotImplementedException($"Trigger for {rpcId} not defined.")
         };
         ITransport? _baseTransport = (ITransport?)BaseSession?.GetType().GetField("_transport", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(BaseSession);
@@ -61,7 +69,7 @@ public partial class TestProtocol : Protocol
     [RpcImplementation(nameof(DivideFloatAsync))]
     public static float DivideFloatImpl(float a, float b)
     {
-        return a/b;
+        return a / b;
     }
 
     [RpcImplementation(nameof(CaesarCipherAsync))]
@@ -78,7 +86,7 @@ public partial class TestProtocol : Protocol
         return data;
     }
 
-    private static T CalculateMinMax<T> (List<short> data) where T : new()
+    private static T CalculateMinMax<T>(List<short> data) where T : new()
     {
         T ret = new();
         var retType = typeof(T);
@@ -89,25 +97,25 @@ public partial class TestProtocol : Protocol
     }
 
     [RpcImplementation(nameof(ListFirstAttrAsync))]
-    public static ListFirstAttr ListFirstAttrImpl (List<short> data)
+    public static ListFirstAttr ListFirstAttrImpl(List<short> data)
     {
         return CalculateMinMax<ListFirstAttr>(data);
     }
 
     [RpcImplementation(nameof(ListMidAttrAsync))]
-    public static ListMidAttr ListMidAttrImpl (List<short> data)
+    public static ListMidAttr ListMidAttrImpl(List<short> data)
     {
         return CalculateMinMax<ListMidAttr>(data);
     }
 
     [RpcImplementation(nameof(ListLastAttrAsync))]
-    public static ListLastAttr ListLastAttrImpl (List<short> data)
+    public static ListLastAttr ListLastAttrImpl(List<short> data)
     {
         return CalculateMinMax<ListLastAttr>(data);
     }
 
     [RpcImplementation(nameof(TwoListAttrAsync))]
-    public static TwoListAttr TwoListAttrImpl (List<short> data_a, List<short> data_b)
+    public static TwoListAttr TwoListAttrImpl(List<short> data_a, List<short> data_b)
     {
         return new TwoListAttr()
         {
@@ -118,9 +126,9 @@ public partial class TestProtocol : Protocol
             DataB = data_b
         };
     }
-    
+
     [RpcImplementation(nameof(EpochToDateAsync))]
-    public static MockDate EpochToDateImpl (int epoch)
+    public static MockDate EpochToDateImpl(int epoch)
     {
         var dt = DateTimeOffset.FromUnixTimeSeconds(epoch);
         MockDate ret = new()

--- a/csharp/tests/CompostRpc.IntegrationTests/TestProtocol/TestProtocol.cs
+++ b/csharp/tests/CompostRpc.IntegrationTests/TestProtocol/TestProtocol.cs
@@ -171,4 +171,14 @@ public partial class TestProtocol(ITransport transport) : Protocol(transport)
         add => AddNotificationHandler(value);
         remove => RemoveNotificationHandler(value);
     }
+
+    /// <summary>
+    /// Sends struct with bitfields
+    /// </summary>
+    [Notification(0xe04)]
+    public event Action<BitfieldStruct, NestedBitfieldStruct> NotifyBitfields
+    {
+        add => AddNotificationHandler(value);
+        remove => RemoveNotificationHandler(value);
+    }
 }

--- a/csharp/tests/CompostRpc.IntegrationTests/TestProtocol/TestProtocolTypes.cs
+++ b/csharp/tests/CompostRpc.IntegrationTests/TestProtocol/TestProtocolTypes.cs
@@ -54,25 +54,33 @@ public enum Voltages : int
 public class BitfieldStruct
 {
     [Pack(8)]
-    public int Channel { get; set; }
+    public uint Channel { get; set; }
     [Pack(5)]
-    public int Inom { get; set; }
+    public uint Inom { get; set; }
     [Pack(4)]
-    public int Hsc { get; set; }
+    public uint Hsc { get; set; }
     [Pack(9)]
-    public int Tnom { get; set; }
+    public uint Tnom { get; set; }
     [Pack(4)]
     public Voltages Temp { get; set; }
     [Pack(3)]
-    public int Ststart { get; set; }
+    public uint Ststart { get; set; }
     [Pack(1)]
-    public int Ccm { get; set; }
+    public uint Ccm { get; set; }
     [Pack(1)]
-    public int Set { get; set; }
+    public uint Set { get; set; }
     [Pack(1)]
-    public int State { get; set; }
+    public uint State { get; set; }
     [Pack(1)]
-    public int Clear { get; set; }
+    public uint Clear { get; set; }
+}
+
+public class NestedBitfieldStruct
+{
+    [Pack(1)]
+    public uint Leading { get; set; }
+    public BitfieldStruct Fields { get; set; } = new();
+    public Status Status { get; set; }
 }
 
 public class ListFirstAttr
@@ -133,7 +141,7 @@ public class MockLogMessage
 {
     public Status Severity { get; set; }
     public string Message { get; set; } = string.Empty;
-    public MockDate Timestamp { get; set; } = new ();
+    public MockDate Timestamp { get; set; } = new();
     public byte ByteXor { get; set; }
 }
 
@@ -141,5 +149,5 @@ public class MockLfsr
 {
     public ulong Polynomial { get; set; }
     public ulong Value { get; set; }
-    public MockDate Timestamp { get; set; } = new ();
+    public MockDate Timestamp { get; set; } = new();
 }

--- a/test/mock/main.c
+++ b/test/mock/main.c
@@ -126,8 +126,35 @@ int main(int argc, char *argv[])
             tx_len = notify_heartbeat_store(tx_buf);
             break;
         case 0x0e03:
-            tx_len = notify_bitwise_complement_store(tx_buf, 0xAAAAAAAAAAAAAAAA, 0x5555555555555555);
+            tx_len =
+                notify_bitwise_complement_store(tx_buf, 0xAAAAAAAAAAAAAAAA, 0x5555555555555555);
             break;
+        case 0x0e04: {
+            struct BitfieldStruct a = {.channel = 0,
+                                       .inom = 1,
+                                       .hsc = 0,
+                                       .tnom = 1,
+                                       .temp = VOLTAGES_MV_110_92,
+                                       .ststart = 1,
+                                       .ccm = 0,
+                                       .set = 1,
+                                       .state = 0,
+                                       .clear = 1};
+            struct NestedBitfieldStruct b = {.leading = 1,
+                                             .fields = {.channel = 0xA5,
+                                                        .inom = 0x12,
+                                                        .hsc = 0x9,
+                                                        .tnom = 0x155,
+                                                        .temp = VOLTAGES_MV_63_08,
+                                                        .ststart = 0x5,
+                                                        .ccm = 1,
+                                                        .set = 0,
+                                                        .state = 1,
+                                                        .clear = 0},
+                                             .status = STATUS_WARN};
+            tx_len = notify_bitfields_store(tx_buf, a, b);
+            break;
+        }
         default:
             notif_requested = false;
             break;

--- a/test/protocol_def.py
+++ b/test/protocol_def.py
@@ -64,6 +64,12 @@ class BitfieldStruct:
     clear:   BitU[1]
 
 @struct
+class NestedBitfieldStruct:
+    leading: BitU[1]
+    fields: BitfieldStruct
+    status: Status
+
+@struct
 class ListFirstAttr:
     data: list[I16]
     min: I16
@@ -215,7 +221,7 @@ class TestProtocol(Protocol):
         """Notifies a value and its bitwise complement."""
 
     @notification(0xE04, direction=CallDirection.TWO_WAY)
-    def notify_bitfields(self, config: BitfieldStruct):
+    def notify_bitfields(self, a: BitfieldStruct, b: NestedBitfieldStruct):
         """Sends struct with bitfields"""
 
     @notification(0xE05, direction=CallDirection.TWO_WAY)

--- a/test/protocol_impl.c
+++ b/test/protocol_impl.c
@@ -7,7 +7,7 @@
 void assert(int x)
 {
     if (!x) {
-        fprintf(stderr, "Assertion failed: %s:%d\n", __FILE__,__LINE__);
+        fprintf(stderr, "Assertion failed: %s:%d\n", __FILE__, __LINE__);
         exit(1);
     }
 }
@@ -46,15 +46,15 @@ float slice_avg(struct CompostSliceI16 data)
 
 #define MOCK_DATE_FMT_LEN 8
 
-void set_mock_date(struct MockDate* dest, time_t epoch)
+void set_mock_date(struct MockDate *dest, time_t epoch)
 {
     if (dest->as_digits.ptr == NULL || dest->as_text.ptr == NULL)
         return;
     struct tm *timeinfo = gmtime(&epoch);
     dest->day = timeinfo->tm_mday;
-    dest->month = timeinfo->tm_mon + 1; 
+    dest->month = timeinfo->tm_mon + 1;
     dest->year = timeinfo->tm_year + 1900;
-    char tmp[dest->as_text.len+1];
+    char tmp[dest->as_text.len + 1];
     snprintf(tmp, sizeof(tmp), "%02d%02d%04d", dest->day, dest->month, dest->year);
     compost_str_copy(dest->as_text, tmp);
     for (int i = 0; i < dest->as_text.len; i++)
@@ -99,7 +99,7 @@ float divide_float_handler(float a, float b)
 }
 
 struct CompostSliceU8 caesar_cipher_handler(struct CompostSliceU8 str, uint8_t offset,
-                                          struct CompostAlloc *alloc)
+                                            struct CompostAlloc *alloc)
 {
     struct CompostSliceU8 ciphertext = compost_slice_u8_new(alloc, str.len);
     for (int i = 0; i < str.len; i++)
@@ -126,7 +126,8 @@ struct CompostSliceU8 sort_bytes_handler(struct CompostSliceU8 data, struct Comp
     return sorted;
 }
 
-struct ListFirstAttr list_first_attr_handler(struct CompostSliceI16 data, struct CompostAlloc *alloc)
+struct ListFirstAttr list_first_attr_handler(struct CompostSliceI16 data,
+                                             struct CompostAlloc *alloc)
 {
     struct ListFirstAttr ret = ListFirstAttr_init(alloc, data.len);
     compost_slice_copy(ret.data, data);
@@ -154,7 +155,7 @@ struct ListLastAttr list_last_attr_handler(struct CompostSliceI16 data, struct C
 }
 
 struct TwoListAttr two_list_attr_handler(struct CompostSliceI16 data_a,
-                                     struct CompostSliceI16 data_b, struct CompostAlloc *alloc)
+                                         struct CompostSliceI16 data_b, struct CompostAlloc *alloc)
 {
     struct TwoListAttr ret = TwoListAttr_init(alloc, data_a.len, data_b.len);
     compost_slice_copy(ret.data_a, data_a);
@@ -184,7 +185,7 @@ struct CompostSliceU8 emoji_handler(struct CompostSliceU8 text, struct CompostAl
 }
 
 struct CompostSliceU32 cat_lists_handler(struct CompostSliceU32 list_a,
-                                       struct CompostSliceU32 list_b, struct CompostAlloc *alloc)
+                                         struct CompostSliceU32 list_b, struct CompostAlloc *alloc)
 {
     struct CompostSliceU32 ret = compost_slice_u32_new(alloc, list_a.len + list_b.len);
     for (int i = 0; i < list_a.len; i++) {
@@ -202,8 +203,7 @@ struct MockLfsr get_random_number_handler(uint64_t seed, uint8_t iter, struct Co
     lfsr.polynomial = 0xD800000000000000; //< Copy this value when reimplementing this test
     // LFSR does not work for seed=0 -> store any other value
     lfsr.value = seed == 0 ? 0x1F2E3D4C5B6A7988 : seed;
-    for (int i = 0; i < iter; i++)
-    {
+    for (int i = 0; i < iter; i++) {
         uint8_t feedback = lfsr.value & 1;
         // Shift the seed to the right by one bit
         lfsr.value >>= 1;
@@ -256,7 +256,7 @@ void notify_motor_report_handler(struct MockMotorReport report)
     assert(report.direction == MOTOR_DIRECTION_UP);
     assert(report.voltage.len == 20);
     assert(report.current.len == 20);
-    
+
     // Send back a notification as an async response
     struct MockMotorControl control = MockMotorControl_init();
     control.state = MOTOR_STATE_STOP;
@@ -278,19 +278,19 @@ void struct_in_param_handler(struct ListFirstAttr structure)
     assert(structure.max == 10);
 }
 
-void notify_bitfields_handler(struct BitfieldStruct config)
+void notify_bitfields_handler(struct BitfieldStruct a, struct NestedBitfieldStruct b)
 {
-    config.ccm = ~config.ccm;
-    config.channel = ~config.channel;
-    config.clear = ~config.clear;
-    config.hsc = ~config.hsc;
-    config.inom = ~config.inom;
-    config.set = ~config.set;
-    config.state = ~config.state;
-    config.ststart = ~config.ststart;
-    config.temp = VOLTAGES_MV_37_50;
-    config.tnom = ~config.tnom;
-    uint16_t tx_len = notify_bitfields_store(tx_buf_notif, config);
+    a.ccm = ~a.ccm;
+    a.channel = ~a.channel;
+    a.clear = ~a.clear;
+    a.hsc = ~a.hsc;
+    a.inom = ~a.inom;
+    a.set = ~a.set;
+    a.state = ~a.state;
+    a.ststart = ~a.ststart;
+    a.temp = VOLTAGES_MV_37_50;
+    a.tnom = ~a.tnom;
+    uint16_t tx_len = notify_bitfields_store(tx_buf_notif, a, b);
     fwrite(tx_buf_notif, 1, tx_len, stdout);
     fflush(stdout);
 }

--- a/test/test_compost.py
+++ b/test/test_compost.py
@@ -6,7 +6,7 @@ from time import sleep, time
 from pathlib import Path
 import argparse
 import protocol_def
-from protocol_def import compost_rpc, MockDate, MotorState, MotorDirection, MockMotorControl, MockMotorReport, BitfieldStruct, Voltages, ListFirstAttr
+from protocol_def import compost_rpc, MockDate, MotorState, MotorDirection, MockMotorControl, MockMotorReport, BitfieldStruct, NestedBitfieldStruct, Status, Voltages, ListFirstAttr
 
 # Get default command to run mock from environment, otherwise use the hardcoded command
 mock_path = os.environ.get('COMPOST_MOCK_PATH')
@@ -131,28 +131,36 @@ def test_floats():
 
 def test_bitints():
     q = Queue()
-    config = BitfieldStruct(channel=0,inom=1,hsc=0,tnom=1,temp=0,ststart=1,ccm=0,set=1,state=0,clear=1)
+    a = BitfieldStruct(channel=0,inom=1,hsc=0,tnom=1,temp=0,ststart=1,ccm=0,set=1,state=0,clear=1)
+    b = NestedBitfieldStruct(
+        leading=1,
+        fields=BitfieldStruct(channel=0xA5, inom=0x12, hsc=0x9, tnom=0x155, temp=Voltages.MV_63_08, ststart=0x5, ccm=1, set=0, state=1, clear=0),
+        status=Status.WARN,
+    )
     
-    def bitfield_handler(payload: BitfieldStruct):
-        q.put(payload)
+    def bitfield_handler(payload_a: BitfieldStruct, payload_b: NestedBitfieldStruct):
+        q.put((payload_a, payload_b))
 
     rpc.notify_bitfields.subscribe(bitfield_handler)
-    rpc.notify_bitfields(config)
+    rpc.notify_bitfields(a, b)
     sleep(0.1)
 
-    payload = q.get()
-    print(f"{config=}")
-    print(f"{payload=}")
-    assert ~config.channel & ((1 << 8) - 1) == payload.channel
-    assert ~config.inom & ((1 << 5) - 1) == payload.inom
-    assert ~config.hsc & ((1 << 4) - 1) == payload.hsc
-    assert ~config.tnom & ((1 << 9) - 1) == payload.tnom
-    assert Voltages.MV_37_50 == payload.temp
-    assert ~config.ststart & ((1 << 3) - 1) == payload.ststart
-    assert ~config.ccm & ((1 << 1) - 1) == payload.ccm
-    assert ~config.set & ((1 << 1) - 1) == payload.set
-    assert ~config.state & ((1 << 1) - 1) == payload.state
-    assert ~config.clear & ((1 << 1) - 1) == payload.clear
+    payload_a, payload_b = q.get()
+    print(f"{a=}")
+    print(f"{payload_a=}")
+    print(f"{b=}")
+    print(f"{payload_b=}")
+    assert ~a.channel & ((1 << 8) - 1) == payload_a.channel
+    assert ~a.inom & ((1 << 5) - 1) == payload_a.inom
+    assert ~a.hsc & ((1 << 4) - 1) == payload_a.hsc
+    assert ~a.tnom & ((1 << 9) - 1) == payload_a.tnom
+    assert Voltages.MV_37_50 == payload_a.temp
+    assert ~a.ststart & ((1 << 3) - 1) == payload_a.ststart
+    assert ~a.ccm & ((1 << 1) - 1) == payload_a.ccm
+    assert ~a.set & ((1 << 1) - 1) == payload_a.set
+    assert ~a.state & ((1 << 1) - 1) == payload_a.state
+    assert ~a.clear & ((1 << 1) - 1) == payload_a.clear
+    assert b == payload_b
 
 def test_nested_structs():
     current_epoch = int(time())


### PR DESCRIPTION
This patch adds a test for serialization of nested bitfield structs and two separate fixes (one in Python, one in C#) that caused this test to fail.